### PR TITLE
Add exception class name to msg

### DIFF
--- a/uw_oidc/exceptions.py
+++ b/uw_oidc/exceptions.py
@@ -6,6 +6,10 @@ Custom exceptions for uw_oidc
 class InvalidTokenError(Exception):
     pass
 
+    def __str__(self):
+        return "{}: {}".format(self.__class__.__name__,
+                               super().__str__())
+
 
 class JwksFetchError(InvalidTokenError):
     pass

--- a/uw_oidc/exceptions.py
+++ b/uw_oidc/exceptions.py
@@ -1,5 +1,9 @@
 """
-Custom exceptions for uw_oidc
+Custom exceptions for uw_oidc.
+All of them are returned with the HTTP response code 401.
+
+If it is a Jwks related exception, check Jwks the site.
+Otherwise the error is caused by the ID token.
 """
 
 

--- a/uw_oidc/id_token.py
+++ b/uw_oidc/id_token.py
@@ -31,9 +31,7 @@ class UWIdPToken(object):
         self.token = token
         self.key_id = self.extract_keyid()
         self.payload = self.get_token_payload()
-        if self.valid_auth_time():
-            return self.payload.get('sub')
-        raise InvalidTokenError("AuthTimedOut")
+        return self.payload.get('sub')
 
     def extract_keyid(self):
         try:
@@ -84,18 +82,3 @@ class UWIdPToken(object):
                            "https://idp-eval.u.washington.edu"),
             audience=getattr(settings, 'UW_TOKEN_AUDIENCE'),
             leeway=int(getattr(settings, 'UW_TOKEN_LEEWAY', 1)))
-
-    def valid_auth_time(self):
-        """
-        Raise InvalidTokenError if the id-token is not fresh enough
-        """
-        timeout = int(getattr(settings, 'UW_TOKEN_MAX_AGE', 0))
-        if timeout == 0:
-            # will not check the auth_time
-            return True
-        age_limit = timegm(datetime.utcnow().utctimetuple()) - timeout
-        try:
-            return int(self.payload['auth_time']) >= age_limit
-        except KeyError as ex:
-            pass
-        return False

--- a/uw_oidc/middleware.py
+++ b/uw_oidc/middleware.py
@@ -20,7 +20,7 @@ class IDTokenAuthenticationMiddleware(MiddlewareMixin):
     def __init__(self, get_response=None):
         self.get_response = get_response
 
-    def process_request(self, request):
+    def process_view(self, request, view_func, view_args, view_kwargs):
         if not hasattr(request, 'session'):
             raise ImproperlyConfigured(
                 'This authentication middleware requires session middleware '
@@ -28,7 +28,6 @@ class IDTokenAuthenticationMiddleware(MiddlewareMixin):
                 '"django.contrib.sessions.middleware.SessionMiddleware" '
                 'before "uw_oidc.middleware.IDTokenAuthenticationMiddleware".')
 
-    def process_view(self, request, view_func, view_args, view_kwargs):
         if 'HTTP_AUTHORIZATION' in request.META:
             try:
                 if request.user.is_authenticated:

--- a/uw_oidc/middleware.py
+++ b/uw_oidc/middleware.py
@@ -52,8 +52,7 @@ class IDTokenAuthenticationMiddleware(MiddlewareMixin):
                                       'user': username,
                                       'url': request.META.get('REQUEST_URI')})
             except InvalidTokenError as ex:
-                return HttpResponse(status=401,
-                                    reason='Invalid token: {}'.format(ex))
+                return HttpResponse(status=401, reason=str(ex))
         return None
 
     def clean_username(self, username):

--- a/uw_oidc/middleware.py
+++ b/uw_oidc/middleware.py
@@ -2,6 +2,7 @@ import logging
 from django.contrib import auth
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
+from django.utils.deprecation import MiddlewareMixin
 from uw_oidc.exceptions import InvalidTokenError
 from uw_oidc.id_token import UWIdPToken
 from uw_oidc.logger import log_err, log_info
@@ -9,7 +10,7 @@ from uw_oidc.logger import log_err, log_info
 logger = logging.getLogger(__name__)
 
 
-class IDTokenAuthenticationMiddleware:
+class IDTokenAuthenticationMiddleware(MiddlewareMixin):
     """
     Supports ID Token (issued by UW OIDC provider)
     based request authentication for specified clients.
@@ -19,7 +20,7 @@ class IDTokenAuthenticationMiddleware:
     def __init__(self, get_response=None):
         self.get_response = get_response
 
-    def process_view(self, request, view_func, view_args, view_kwargs):
+    def process_request(self, request):
         if not hasattr(request, 'session'):
             raise ImproperlyConfigured(
                 'This authentication middleware requires session middleware '
@@ -27,15 +28,17 @@ class IDTokenAuthenticationMiddleware:
                 '"django.contrib.sessions.middleware.SessionMiddleware" '
                 'before "uw_oidc.middleware.IDTokenAuthenticationMiddleware".')
 
+    def process_view(self, request, view_func, view_args, view_kwargs):
         if 'HTTP_AUTHORIZATION' in request.META:
             try:
                 if request.user.is_authenticated:
-                    # not validate ID token on every request
+                    # honor the existing session
                     return None
 
                 # We are seeing this user for the first time in this
                 # session, attempt to authenticate the user.
-                token = request.META['HTTP_AUTHORIZATION']
+                token = request.META['HTTP_AUTHORIZATION'].replace(
+                    'Bearer ', '', 1)
                 username = self.clean_username(
                     UWIdPToken().username_from_token(token))
 
@@ -46,19 +49,11 @@ class IDTokenAuthenticationMiddleware:
                     auth.login(request, user)
                     request.session[self.TOKEN_SESSION_KEY] = token
                     log_info(logger, {'msg': "Login token based session",
-                                      'user': username})
+                                      'user': username,
+                                      'url': request.META.get('REQUEST_URI')})
             except InvalidTokenError as ex:
                 return HttpResponse(status=401,
                                     reason='Invalid token: {}'.format(ex))
-        else:
-            if (request.user.is_authenticated and
-                    self.TOKEN_SESSION_KEY in request.session):
-                # The session was established based on a valid token
-                # but the request has no token, revoke the existing session.
-                log_err(logger, {'msg': "Revoke token based session",
-                                 'user': request.user.get_username()})
-                auth.logout(request)
-
         return None
 
     def clean_username(self, username):

--- a/uw_oidc/tests/test_middleware.py
+++ b/uw_oidc/tests/test_middleware.py
@@ -38,7 +38,8 @@ class TestMiddleware(TestCase):
         request = self.factory.get('/')
         middleware = IDTokenAuthenticationMiddleware()
         self.assertRaises(
-            ImproperlyConfigured, middleware.process_request, request)
+            ImproperlyConfigured, middleware.process_view, request,
+            None, None, None)
 
     @patch.object(UWIdPToken, 'username_from_token')
     def test_process_view_invalid_token(self, mock_username_from_token):
@@ -96,7 +97,6 @@ class TestMiddleware(TestCase):
         request = self.create_authenticated_request()
         middleware = IDTokenAuthenticationMiddleware()
         del request.META['HTTP_AUTHORIZATION']
-        middleware.process_request(request)
         response = middleware.process_view(request, None, None, None)
         self.assertEqual(response, None)
         self.assertTrue(request.user.is_authenticated)

--- a/uw_oidc/tests/test_middleware.py
+++ b/uw_oidc/tests/test_middleware.py
@@ -38,8 +38,7 @@ class TestMiddleware(TestCase):
         request = self.factory.get('/')
         middleware = IDTokenAuthenticationMiddleware()
         self.assertRaises(
-            ImproperlyConfigured, middleware.process_view, request,
-            None, None, None)
+            ImproperlyConfigured, middleware.process_request, request)
 
     @patch.object(UWIdPToken, 'username_from_token')
     def test_process_view_invalid_token(self, mock_username_from_token):
@@ -50,7 +49,7 @@ class TestMiddleware(TestCase):
         response = middleware.process_view(request, None, None, None)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.reason_phrase,
-                         'Invalid token: Not enough segments')
+                         'InvalidTokenError: Not enough segments')
 
     @patch.object(UWIdPToken, 'username_from_token')
     def test_process_view_expired_token(self, mock_username_from_token):
@@ -61,7 +60,7 @@ class TestMiddleware(TestCase):
         response = middleware.process_view(request, None, None, None)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.reason_phrase,
-                         'Invalid token: ExpiredSignatureError')
+                         'InvalidTokenError: ExpiredSignatureError')
 
     @patch.object(UWIdPToken, 'username_from_token', return_value='')
     def test_process_view_invalid_username(self, mock_fn):
@@ -70,7 +69,7 @@ class TestMiddleware(TestCase):
         response = middleware.process_view(request, None, None, None)
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.reason_phrase,
-                         'Invalid token: Missing username')
+                         'InvalidTokenError: Missing username')
 
     def test_process_view_already_authenticated(self):
         request = self.create_authenticated_request()
@@ -93,18 +92,15 @@ class TestMiddleware(TestCase):
         self.assertEqual(
             request.session.get(middleware.TOKEN_SESSION_KEY), 'abc')
 
-    def test_token_authn_session_req_wo_token(self):
+    def test_authed_session_req_wo_token(self):
         request = self.create_authenticated_request()
         middleware = IDTokenAuthenticationMiddleware()
         del request.META['HTTP_AUTHORIZATION']
+        middleware.process_request(request)
         response = middleware.process_view(request, None, None, None)
         self.assertEqual(response, None)
-
-        # Check that user has been logged out
-        self.assertFalse(request.user.is_authenticated)
-        # session token deleted
-        with self.assertRaises(KeyError) as raises:
-            request.session[middleware.TOKEN_SESSION_KEY]
+        self.assertTrue(request.user.is_authenticated)
+        self.assertIsNotNone(request.session[middleware.TOKEN_SESSION_KEY])
 
     def test_clean_username(self):
         request = self.create_unauthenticated_request()


### PR DESCRIPTION
1. Not every request has authentication header, remove the corresponding check and logout call.
2. Remove the checking for auth_time.
3. Add class name in the exception message string